### PR TITLE
amend so that feedback bands are sorted by _score

### DIFF
--- a/js/adapt-contrib-assessmentResults.js
+++ b/js/adapt-contrib-assessmentResults.js
@@ -151,11 +151,10 @@ define(function(require) {
         getFeedbackBand: function() {
             var state = this.model.get("_state");
 
-            var bands = this.model.get("_bands");
-            var scoreAsPercent = state.scoreAsPercent;
+            var bands = _.sortBy(this.model.get("_bands"), '_score');
             
             for (var i = (bands.length - 1); i >= 0; i--) {
-                if (scoreAsPercent >= bands[i]._score) {
+                if (state.scoreAsPercent >= bands[i]._score) {
                     return bands[i];
                 }
             }


### PR DESCRIPTION
removes need to specify the bands in a particular order in the JSON. Fixes [ABU-1145](https://adaptlearning.atlassian.net/browse/ABU-1145)