### PR TITLE
add function addClassesToArticle

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,15 @@ guide the learner’s interaction with the component.
   
 **_completionBody** (string): This text overwrites the standard **body** attribute upon completion of the assessment. It may make use of the following variables: `{{attemptsSpent}}`, `{{attempts}}`, `{{attemptsLeft}}`, `{{{score}}}`, `{{{maxScore}}}`. The variable `{{{feedback}}}`, representing the feedback assigned to the appropriate band, is also allowed.  
 
-**_bands** (object array): Multiple items may be created. Each item represents the feedback and opportunity to retry for the appropriate range of scores. **_bands** contains values for **_score**, **feedback**, and **_allowRetry**.
+**_bands** (object array): Multiple items may be created. Each item represents the feedback and opportunity to retry for the appropriate range of scores. **_bands** contains values for **_score**, **feedback**, **_allowRetry** and **_classes**.
 
 >**_score** (number):  This numeric value represents the raw score or percentile (as determined by the configuration of [adapt-contrib-assessment](https://github.com/adaptlearning/adapt-contrib-assessment)) that indicates the low end or start of the range. The range continues to the next highest **_score** of another band.
 
 >**feedback** (string): This text will be displayed to the learner when the learner's score falls within this band's range. It replaces the `{{{feedback}}}` variable when the variable is used within **_completionBody**.
 
 >**_allowRetry** (boolean): Determines whether the learner will be allowed to reattempt the assessment. If the value is `false`, the learner will not be allowed to retry the assessment regardless of any remaining attempts.  
+
+>**_classes** (string): Classes that will be applied to the containing article if the user's score falls into this band. Allows for custom styling based on the feedback band.  
 
 <div float align=right><a href="#top">Back to Top</a></div>
 
@@ -81,7 +83,7 @@ In the image to the right, numbers are paired with the text's source attributes 
 No known limitations.  
 
 ----------------------------
-**Version number:**  2.0.2   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>   
+**Version number:**  2.0.3   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>   
 **Framework versions:** 2.0  
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-assessmentResults/graphs/contributors)    
 **Accessibility support:** WAI AA   

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-assessmentResults",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "framework": "^2.0.0",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-assessmentResults",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-assessmentResults%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",

--- a/example.json
+++ b/example.json
@@ -39,7 +39,8 @@
       {
         "_score": 75,
         "feedback": "Great work. You passed your assessment with {{{scoreAsPercent}}}%.",
-        "_allowRetry": false
+        "_allowRetry": false,
+		"_classes": "high-score"
       }
     ]
   },

--- a/js/adapt-contrib-assessmentResults.js
+++ b/js/adapt-contrib-assessmentResults.js
@@ -89,7 +89,12 @@ define(function(require) {
                 this.model.get("_assessmentId") != state.id) return;
 
             this.model.set("_state", state);
-            this.setFeedback();
+            
+            var feedbackBand = this.getFeedbackBand();
+            
+            this.setFeedback(feedbackBand);
+            
+            this.addClassesToArticle(feedbackBand);
 
             //show feedback component
             this.render();
@@ -99,7 +104,12 @@ define(function(require) {
 
         onAssessmentComplete: function(state) {
             this.model.set("_state", state);
-            this.setFeedback();
+            
+            var feedbackBand = this.getFeedbackBand(feedbackBand);
+            
+            this.setFeedback(feedbackBand);
+            
+            this.addClassesToArticle(feedbackBand);
 
              //show feedback component
             if(!this.model.get('_isVisible')) this.model.set('_isVisible', true, {pluginName: "assessmentResults"});
@@ -131,10 +141,9 @@ define(function(require) {
             assessmentModel.reset();
         },
 
-        setFeedback: function() {
+        setFeedback: function(feedbackBand) {
 
             var completionBody = this.model.get("_completionBody");
-            var feedbackBand = this.getFeedbackBand();
 
             var state = this.model.get("_state");
             state.feedbackBand = feedbackBand;
@@ -146,6 +155,17 @@ define(function(require) {
 
             this.model.set("body", completionBody);
 
+        },
+        
+        /**
+         * If there are classes specified for the feedback band, apply them to the containing article
+         * This allows for custom styling based on the band the user's score falls into
+         */
+        addClassesToArticle: function(feedbackBand) {
+            
+            if(!feedbackBand.hasOwnProperty('_classes')) return;
+            
+            this.$el.parents('.article').addClass(feedbackBand._classes);
         },
 
         getFeedbackBand: function() {

--- a/js/adapt-contrib-assessmentResults.js
+++ b/js/adapt-contrib-assessmentResults.js
@@ -105,7 +105,7 @@ define(function(require) {
         onAssessmentComplete: function(state) {
             this.model.set("_state", state);
             
-            var feedbackBand = this.getFeedbackBand(feedbackBand);
+            var feedbackBand = this.getFeedbackBand();
             
             this.setFeedback(feedbackBand);
             

--- a/js/adapt-contrib-assessmentResults.js
+++ b/js/adapt-contrib-assessmentResults.js
@@ -96,10 +96,9 @@ define(function(require) {
             
             this.addClassesToArticle(feedbackBand);
 
-            //show feedback component
             this.render();
-            if(!this.model.get('_isVisible')) this.model.set('_isVisible', true, {pluginName: "assessmentResults"});
             
+            this.show();
         },
 
         onAssessmentComplete: function(state) {
@@ -111,9 +110,9 @@ define(function(require) {
             
             this.addClassesToArticle(feedbackBand);
 
-             //show feedback component
-            if(!this.model.get('_isVisible')) this.model.set('_isVisible', true, {pluginName: "assessmentResults"});
             this.render();
+            
+            this.show();
         },
 
         onInview: function(event, visible, visiblePartX, visiblePartY) {
@@ -139,6 +138,12 @@ define(function(require) {
             var assessmentModel = Adapt.assessment.get(state.id);
 
             assessmentModel.reset();
+        },
+        
+        show: function() {
+             if(!this.model.get('_isVisible')) {
+                 this.model.set('_isVisible', true, {pluginName: "assessmentResults"});
+             }
         },
 
         setFeedback: function(feedbackBand) {

--- a/properties.schema
+++ b/properties.schema
@@ -99,7 +99,16 @@
             "default": true,
             "title": "Allow Retry",
             "inputType": {"type": "Boolean", "options": [true, false]},
-            "validators": []          }
+            "validators": []          
+	  },
+	  "_classes": {
+	    "type": "string",
+            "required": false,
+            "default": "",
+            "inputType": "Text",
+            "validators": [],
+	    "help": "Classes to be applied to the containing article; allows for custom styling based on the band the user's score falls into."
+          }
         }
       }
     }


### PR DESCRIPTION
so as to enable adding custom classes on the article depending on what 'band' the user's score falls into (see [#1003](https://github.com/adaptlearning/adapt_framework/issues/1003))

update properties.schema, example.json and README.md with the new property; bump the version in README.md and bower.json