### PR TITLE
Issue/2278

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ guide the learner’s interaction with the component.
 >**button** (string): Text that appears on the retry button.
 
 >**feedback** (string): This text is displayed only when both **_allowRetry** is `true` and more attempts remain ([configured in adapt-contrib-assessment](https://github.com/adaptlearning/adapt-contrib-assessment#attributes)). It may make use of the following variables: `{{attemptsSpent}}`, `{{attempts}}`, `{{attemptsLeft}}`, `{{score}}`, `{{scoreAsPercent}}` and `{{maxScore}}`. These values are populated with data supplied by [adapt-contrib-assessment](https://github.com/adaptlearning/adapt-contrib-assessment#attributes). `{{{feedback}}}`, representing the feedback assigned to the appropriate band within this component, is also allowed.  
+
+**_routeToAssessment** (boolean): Determines whether the user should be redirected back (or scrolled up) to the assessment for another attempt when the retry button is clicked.
   
 **_completionBody** (string): This text overwrites the standard **body** attribute upon completion of the assessment. It may make use of the following variables: `{{attemptsSpent}}`, `{{attempts}}`, `{{attemptsLeft}}`, `{{score}}`, `{{scoreAsPercent}}` and `{{maxScore}}`. The variable `{{{feedback}}}`, representing the feedback assigned to the appropriate band, is also allowed.  
 
@@ -91,7 +93,7 @@ For a guide on the difference between using two curly braces and three curly bra
 No known limitations.  
 
 ----------------------------
-**Version number:**  2.3.1   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>   
+**Version number:**  2.3.2   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>   
 **Framework versions:** 2.1+  
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-assessmentResults/graphs/contributors)    
 **Accessibility support:** WAI AA   

--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ guide the learner’s interaction with the component.
 
 **_resetType** (string): Valid values are: `"hard"`, `"soft"` and `"inherit"`. Controls whether this component does a 'soft' or 'hard' reset when the corresponding assessment is reset. A 'soft' reset will reset everything except component completion; a 'hard' reset will reset component completion as well, requiring the user to complete this component again. If you want this component to have the same reset behaviour as the corresponding assessment you can leave this property out - or set it to 'inherit'. 
 
-**_retry** (object): Contains values for **button** and **feedback**. 
+**_retry** (object): Contains values for **button**, **feedback** and **_routeToAssessment**. 
 
 >**button** (string): Text that appears on the retry button.
 
 >**feedback** (string): This text is displayed only when both **_allowRetry** is `true` and more attempts remain ([configured in adapt-contrib-assessment](https://github.com/adaptlearning/adapt-contrib-assessment#attributes)). It may make use of the following variables: `{{attemptsSpent}}`, `{{attempts}}`, `{{attemptsLeft}}`, `{{score}}`, `{{scoreAsPercent}}` and `{{maxScore}}`. These values are populated with data supplied by [adapt-contrib-assessment](https://github.com/adaptlearning/adapt-contrib-assessment#attributes). `{{{feedback}}}`, representing the feedback assigned to the appropriate band within this component, is also allowed.  
 
-**_routeToAssessment** (boolean): Determines whether the user should be redirected back (or scrolled up) to the assessment for another attempt when the retry button is clicked.
+>**_routeToAssessment** (boolean): Determines whether the user should be redirected back (or scrolled up) to the assessment for another attempt when the retry button is clicked.
   
 **_completionBody** (string): This text overwrites the standard **body** attribute upon completion of the assessment. It may make use of the following variables: `{{attemptsSpent}}`, `{{attempts}}`, `{{attemptsLeft}}`, `{{score}}`, `{{scoreAsPercent}}` and `{{maxScore}}`. The variable `{{{feedback}}}`, representing the feedback assigned to the appropriate band, is also allowed.  
 
@@ -70,7 +70,7 @@ guide the learner’s interaction with the component.
 
 >**feedback** (string): This text will be displayed to the learner when the learner's score falls within this band's range. It replaces the `{{{feedback}}}` variable when the variable is used within **_completionBody**.
 
->**_allowRetry** (boolean): Determines whether the learner will be allowed to reattempt the assessment. If the value is `false`, the learner will not be allowed to retry the assessment regardless of any remaining attempts.  
+>**_allowRetry** (boolean): Determines whether the learner will be allowed to reattempt the assessment. If the value is `false`, the learner will not be allowed to retry the assessment regardless of any remaining attempts. 
 
 >**_classes** (string): Classes that will be applied to the containing article if the user's score falls into this band. Allows for custom styling based on the feedback band.  
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ For a guide on the difference between using two curly braces and three curly bra
 No known limitations.  
 
 ----------------------------
-**Version number:**  2.3.2   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>   
+**Version number:**  2.4.0   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>   
 **Framework versions:** 2.1+  
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-assessmentResults/graphs/contributors)    
 **Accessibility support:** WAI AA   

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-assessmentResults",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "framework": ">=2.1",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-assessmentResults",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-assessmentResults",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "framework": ">=2.1",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-assessmentResults",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",

--- a/example.json
+++ b/example.json
@@ -21,6 +21,7 @@
         "button": "Retry Assessment",
         "feedback": "Why not have another try? You have used {{attemptsSpent}} of {{attempts}} attempt(s), which means you have {{attemptsLeft}} attempt(s) remaining."
     },
+    "_routeToAssessment": true,
     "_completionBody" : "This component you're reading is a results component.<br>You have finished the assessment.<br>You scored {{{score}}} out of {{{maxScore}}}. {{{feedback}}}",
     "_bands": [
         {

--- a/example.json
+++ b/example.json
@@ -19,9 +19,9 @@
     "_assessmentId": "Assessment 1",
     "_retry": {
         "button": "Retry Assessment",
-        "feedback": "Why not have another try? You have used {{attemptsSpent}} of {{attempts}} attempt(s), which means you have {{attemptsLeft}} attempt(s) remaining."
+        "feedback": "Why not have another try? You have used {{attemptsSpent}} of {{attempts}} attempt(s), which means you have {{attemptsLeft}} attempt(s) remaining.",
+        "_routeToAssessment": true
     },
-    "_routeToAssessment": true,
     "_completionBody" : "This component you're reading is a results component.<br>You have finished the assessment.<br>You scored {{{score}}} out of {{{maxScore}}}. {{{feedback}}}",
     "_bands": [
         {

--- a/js/assessmentResultsView.js
+++ b/js/assessmentResultsView.js
@@ -61,8 +61,8 @@ define([
 
             Adapt.assessment.get(state.id).reset();
 
-            if (this.model.get('_routeToAssessment') === true) {
-                Adapt.trigger('router:navigateTo', [state.articleId]);
+            if (this.model.get('_retry')._routeToAssessment === true) {
+                Adapt.navigateToElement('.' + state.articleId);
             }
         },
 

--- a/js/assessmentResultsView.js
+++ b/js/assessmentResultsView.js
@@ -52,9 +52,18 @@ define([
             }
         },
 
+        /**
+         * Resets the state of the assessment and optionally redirects the user
+         * back to the assessment for another attempt.
+         */
         onRetryClicked: function() {
-            var assessmentId = this.model.get('_state').id;
-            Adapt.assessment.get(assessmentId).reset();
+            var state = this.model.get('_state');
+
+            Adapt.assessment.get(state.id).reset();
+
+            if (this.model.get('_routeToAssessment') === true) {
+                Adapt.trigger('router:navigateTo', [state.articleId]);
+            }
         },
 
         /**
@@ -62,7 +71,7 @@ define([
          * This allows for custom styling based on the band the user's score falls into
          */
         addClassesToArticle: function(model, value) {
-            if (!value._classes) return;
+            if (!value || !value._classes) return;
 
             this.$el.parents('.article').addClass(value._classes);
         }

--- a/properties.schema
+++ b/properties.schema
@@ -101,6 +101,15 @@
         }
       }
     },
+    "_routeToAssessment": {
+      "type": "boolean",
+      "required": true,
+      "default": false,
+      "title": "Redirect to assessment on retry",
+      "inputType": "Checkbox",
+      "validators": [],
+      "help": "When enabled, this will take the user back to the assessment when the \"Retry Assessment\" button is clicked."
+    },
     "_completionBody": {
       "type": "string",
       "required": false,

--- a/properties.schema
+++ b/properties.schema
@@ -98,17 +98,17 @@
           "validators": [],
           "help": "This text is displayed only when more attempts remain. You can use the following variables: {{attemptsSpent}}, {{attempts}}, {{attemptsLeft}}, {{{score}}}, {{{maxScore}}}.",
           "translatable": true
+        },
+        "_routeToAssessment": {
+          "type": "boolean",
+          "required": true,
+          "default": false,
+          "title": "Redirect to assessment on retry",
+          "inputType": "Checkbox",
+          "validators": [],
+          "help": "When enabled, this will take the user back to the assessment when the \"Retry Assessment\" button is clicked."
         }
       }
-    },
-    "_routeToAssessment": {
-      "type": "boolean",
-      "required": true,
-      "default": false,
-      "title": "Redirect to assessment on retry",
-      "inputType": "Checkbox",
-      "validators": [],
-      "help": "When enabled, this will take the user back to the assessment when the \"Retry Assessment\" button is clicked."
     },
     "_completionBody": {
       "type": "string",


### PR DESCRIPTION
This is the same PR into `master` as https://github.com/adaptlearning/adapt-contrib-assessmentResults/pull/49 was into legacy (v2.4.0).

I can bump the version number to something more appropriate if required, i.e. something which indicates that this contains v4 references changes.