### PR TITLE
issue/3130 Simplify visibility calculations

### DIFF
--- a/js/assessmentResultsModel.js
+++ b/js/assessmentResultsModel.js
@@ -39,13 +39,13 @@ define([
 
     onAssessmentComplete(state) {
       if (this.get('_assessmentId') === undefined ||
-          this.get('_assessmentId') != state.id) return;
+          this.get('_assessmentId') !== state.id) return;
 
       /*
       make shortcuts to some of the key properties in the state object so that
       content developers can just use {{attemptsLeft}} in json instead of {{state.attemptsLeft}}
       */
-      this.set( {
+      this.set({
         _state: state,
         attempts: state.attempts,
         attemptsSpent: state.attemptsSpent,
@@ -70,7 +70,7 @@ define([
       const bands = _.sortBy(this.get('_bands'), '_score');
 
       for (let i = (bands.length - 1); i >= 0; i--) {
-        const isScoreInBandRange =  (state[scoreProp] >= bands[i]._score);
+        const isScoreInBandRange = (state[scoreProp] >= bands[i]._score);
         if (!isScoreInBandRange) continue;
 
         this.set('_feedbackBand', bands[i]);
@@ -108,21 +108,14 @@ define([
     setVisibility() {
       if (!Adapt.assessment) return;
 
-      const isVisibleBeforeCompletion = this.get('_isVisibleBeforeCompletion') || false;
-      const wasVisible = this.get('_isVisible');
-
       const assessmentModel = Adapt.assessment.get(this.get('_assessmentId'));
       if (!assessmentModel || assessmentModel.length === 0) return;
 
       const state = assessmentModel.getState();
-      const isComplete = state.isComplete;
       const isAttemptInProgress = state.attemptInProgress;
-      const attemptsSpent = state.attemptsSpent;
-      const hasHadAttempt = (!isAttemptInProgress && attemptsSpent > 0);
-
-      const isVisible = (isVisibleBeforeCompletion && !isComplete) || hasHadAttempt;
-
-      if (!wasVisible && isVisible) isVisible = false;
+      const isComplete = !isAttemptInProgress && state.isComplete;
+      const isVisibleBeforeCompletion = this.get('_isVisibleBeforeCompletion') || false;
+      const isVisible = isVisibleBeforeCompletion || isComplete;
 
       this.toggleVisibility(isVisible);
     }
@@ -149,7 +142,7 @@ define([
      */
     onAssessmentReset(state) {
       if (this.get('_assessmentId') === undefined ||
-          this.get('_assessmentId') != state.id) return;
+          this.get('_assessmentId') !== state.id) return;
 
       let resetType = this.get('_resetType');
       if (!resetType || resetType === 'inherit') {


### PR DESCRIPTION
fixes #3130

### Fixed
* `_isVisible` is only set to `false` when the assessment is not complete, an attempt is in progress and `_isVisibleBeforeCompletion` is set to `false`

### Changed
* Linting whitespace and operators