### PR TITLE
Fix: Add default schema value for _completionBody (fixes #78)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -121,7 +121,7 @@
     "_completionBody": {
       "type": "string",
       "required": false,
-      "default": "",
+      "default": "This component you're reading is a results component.<br>You have finished the assessment.<br>You scored {{{score}}} out of {{{maxScore}}}. {{{feedback}}}",
       "title": "Feedback Text",
       "inputType": "TextArea",
       "validators": [],

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -99,7 +99,7 @@
           "type": "string",
           "title": "Default feedback",
           "description": "This text overwrites the standard body attribute upon completion of the assessment. It may make use of the following variables: {{attemptsSpent}}, {{attempts}}, {{attemptsLeft}}, {{{score}}}, {{{maxScore}}}. {{{feedback}}}, representing the feedback assigned to the appropriate band, is also allowed",
-          "default": "",
+          "default": "This component you're reading is a results component.<br>You have finished the assessment.<br>You scored {{{score}}} out of {{{maxScore}}}. {{{feedback}}}",
           "_adapt": {
             "translatable": true
           },


### PR DESCRIPTION
Fix #78 

### Fix
* Add default schema value for `_completionBody`. The value is the same as what is in the _example.json_ file.