### PR TITLE
New: Add feedbackNotFinal optional attribute (fixes #74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ guide the learner’s interaction with the component.
 
 >**feedback** (string): This text will be displayed to the learner when the learner's score falls within this band's range. It replaces the `{{{feedback}}}` variable when the variable is used within **\_completionBody**.
 
+>**feedbackNotFinal** (string): This attribute is similar to `feedback`. However, it will be displayed to the learner instead of the `feedback` text if there are remaining attempts. This attribute is _optional_ and the `feedback` text will be shown if `feedbackNotFinal` is not set.
+
 >**\_allowRetry** (boolean): Determines whether the learner will be allowed to reattempt the assessment. If the value is `false`, the learner will not be allowed to retry the assessment regardless of any remaining attempts.
 
 >**\_classes** (string): Classes that will be applied to the containing article if the user's score falls into this band. Allows for custom styling based on the feedback band.
@@ -92,7 +94,7 @@ No known limitations.
 
 ----------------------------
 <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>
-**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-assessmentResults/graphs/contributors)
-**Accessibility support:** WAI AA
-**RTL support:** Yes
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 12+13 for macOS/iOS/iPadOS, Opera
+**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-assessmentResults/graphs/contributors)<br>
+**Accessibility support:** WAI AA<br>
+**RTL support:** Yes<br>
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 12+13 for macOS/iOS/iPadOS, Opera<br>

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ guide the learner’s interaction with the component.
 
 >**feedback** (string): This text will be displayed to the learner when the learner's score falls within this band's range. It replaces the `{{{feedback}}}` variable when the variable is used within **\_completionBody**.
 
->**feedbackNotFinal** (string): This attribute is similar to `feedback`. However, it will be displayed to the learner instead of the `feedback` text if there are remaining attempts. This attribute is _optional_ and the `feedback` text will be shown if `feedbackNotFinal` is not set.
+>**feedbackNotFinal** (string): This attribute is similar to `feedback`. However, it will be displayed to the learner instead of the `feedback` text if there are remaining attempts. This attribute is _optional_ and the `feedback` text will be shown if `feedbackNotFinal` is not set. This attribute is not used if the learner passed the assessment.
 
 >**\_allowRetry** (boolean): Determines whether the learner will be allowed to reattempt the assessment. If the value is `false`, the learner will not be allowed to retry the assessment regardless of any remaining attempts.
 

--- a/example.json
+++ b/example.json
@@ -25,16 +25,19 @@
         "_bands": [
             {
                 "_score": 0,
+                "feedbackNotFinal": "Sorry, but you didn't pass. Take some time to review the course before giving it another try.",
                 "feedback": "Your score was below 25%.",
                 "_allowRetry": true
             },
             {
                 "_score": 25,
+                "feedbackNotFinal": "Sorry, but you didn't pass. Up for another try?",
                 "feedback": "Your score was below 50%.",
                 "_allowRetry": true
             },
             {
                 "_score": 50,
+                "feedbackNotFinal": "Nice try, but you didn't pass. Want to give it another go?",
                 "feedback": "Good effort, but your score was under 75%.",
                 "_allowRetry": true
             },

--- a/js/assessmentResultsModel.js
+++ b/js/assessmentResultsModel.js
@@ -56,13 +56,9 @@ export default class AssessmentResultsModel extends ComponentModel {
     });
 
     this.setFeedbackBand(state);
-
     this.setIsAttemptsLeft(state);
-
     this.checkRetryEnabled(state);
-
     this.setFeedbackText();
-
     this.toggleVisibility(true);
   }
 

--- a/js/assessmentResultsModel.js
+++ b/js/assessmentResultsModel.js
@@ -98,17 +98,20 @@ export default class AssessmentResultsModel extends ComponentModel {
     });
   }
 
-  setFeedbackText() {
+  getFeedbackText() {
     const feedbackBand = this.get('_feedbackBand');
-    let feedback = '';
 
-    if (feedbackBand) {
-      feedback = feedbackBand.feedback;
-    }
+    if (!feedbackBand) return '';
 
     if (this.get('isAttemptsLeft') && feedbackBand?.feedbackNotFinal) {
-      feedback = feedbackBand.feedbackNotFinal;
+      return feedbackBand.feedbackNotFinal;
     }
+
+    return feedbackBand.feedback;
+  }
+
+  setFeedbackText() {
+    const feedback = this.getFeedbackText();
 
     this.set({
       feedback: Handlebars.compile(feedback)(this.toJSON()),

--- a/properties.schema
+++ b/properties.schema
@@ -151,7 +151,18 @@
             "inputType": "TextArea",
             "validators": [],
             "translatable": true,
+            "title": "Feedback",
             "help": "This text will be displayed to the learner when the learner's score falls within this band's range."
+          },
+          "feedbackNotFinal": {
+            "type": "string",
+            "required": false,
+            "default": "",
+            "inputType": "TextArea",
+            "validators": [],
+            "translatable": true,
+            "title": "Feedback (not final attempt)",
+            "help": "This optional text will be displayed to the learner when the learner's score falls within this band's range and when the learner still has attempts remaining."
           },
           "_allowRetry": {
             "type": "boolean",

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -127,6 +127,16 @@
                 },
                 "_backboneForms": "TextArea"
               },
+              "feedbackNotFinal": {
+                "type": "string",
+                "title": "Feedback (not final attempt)",
+                "description": "This optional text will be displayed to the learner when the learner's score falls within this band's range and when the learner still has attempts remaining.",
+                "default": "",
+                "_adapt": {
+                  "translatable": true
+                },
+                "_backboneForms": "TextArea"
+              },
               "_allowRetry": {
                 "type": "boolean",
                 "title": "Allow retry",


### PR DESCRIPTION
Fixes #74 

### Fix
* Adds the `feedbackNotFinal` optional attribute

### Testing
1. In an Assessment Results component, add `feedbackNotFinal` attributes to any non-passing scoring band.
2. Configure the assessment `_attempts` to "infinite". The "not final" feedback should show with every fail.
3. Configure the assessment `_attempts` to a number greater than 1. The "not final" feedback should show with every fail unless attempts have been used up. In that case, the `feedback` text should appear.
4. Configure the assessment `_attempts` to exactly 1. The "not final" feedback should never appear and the `feedback` text should appear.
