### PR TITLE
Fix: Add scoreAsPercent to help text, remove unnecessary triple squigglies (fixes #82)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -104,7 +104,7 @@
           "title": "Retry Text",
           "inputType": "TextArea",
           "validators": [],
-          "help": "This text is displayed only when more attempts remain. You can use the following variables: {{attemptsSpent}}, {{attempts}}, {{attemptsLeft}}, {{{score}}}, {{{maxScore}}}.",
+          "help": "This text is displayed only when more attempts remain. You can use the following variables: {{attemptsSpent}}, {{attempts}}, {{attemptsLeft}}, {{{score}}}, {{scoreAsPercent}} and {{{maxScore}}}.",
           "translatable": true
         },
         "_routeToAssessment": {
@@ -125,7 +125,7 @@
       "title": "Feedback Text",
       "inputType": "TextArea",
       "validators": [],
-      "help": "This text overwrites the standard body attribute upon completion of the assessment. It may make use of the following variables: {{attemptsSpent}}, {{attempts}}, {{attemptsLeft}}, {{{score}}}, {{{maxScore}}}. {{{feedback}}}, representing the feedback assigned to the appropriate band, is also allowed.",
+      "help": "This text overwrites the standard body attribute upon completion of the assessment. It may make use of the following variables: {{attemptsSpent}}, {{attempts}}, {{attemptsLeft}}, {{{score}}}, {{scoreAsPercent}} and {{{maxScore}}}. {{{feedback}}}, representing the feedback assigned to the appropriate band, is also allowed.",
       "translatable": true
     },
     "_bands": {

--- a/properties.schema
+++ b/properties.schema
@@ -104,7 +104,7 @@
           "title": "Retry Text",
           "inputType": "TextArea",
           "validators": [],
-          "help": "This text is displayed only when more attempts remain. You can use the following variables: {{attemptsSpent}}, {{attempts}}, {{attemptsLeft}}, {{{score}}}, {{scoreAsPercent}} and {{{maxScore}}}.",
+          "help": "This text is displayed only when more attempts remain. You can use the following variables: {{attemptsSpent}}, {{attempts}}, {{attemptsLeft}}, {{score}}, {{scoreAsPercent}} and {{maxScore}}.",
           "translatable": true
         },
         "_routeToAssessment": {
@@ -121,11 +121,11 @@
     "_completionBody": {
       "type": "string",
       "required": false,
-      "default": "This component you're reading is a results component.<br>You have finished the assessment.<br>You scored {{{score}}} out of {{{maxScore}}}. {{{feedback}}}",
+      "default": "This component you're reading is a results component.<br>You have finished the assessment.<br>You scored {{score}} out of {{maxScore}}. {{{feedback}}}",
       "title": "Feedback Text",
       "inputType": "TextArea",
       "validators": [],
-      "help": "This text overwrites the standard body attribute upon completion of the assessment. It may make use of the following variables: {{attemptsSpent}}, {{attempts}}, {{attemptsLeft}}, {{{score}}}, {{scoreAsPercent}} and {{{maxScore}}}. {{{feedback}}}, representing the feedback assigned to the appropriate band, is also allowed.",
+      "help": "This text overwrites the standard body attribute upon completion of the assessment. It may make use of the following variables: {{attemptsSpent}}, {{attempts}}, {{attemptsLeft}}, {{score}}, {{scoreAsPercent}} and {{maxScore}}. {{{feedback}}}, representing the feedback assigned to the appropriate band, is also allowed.",
       "translatable": true
     },
     "_bands": {

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -80,7 +80,7 @@
             "feedback": {
               "type": "string",
               "title": "Retry feedback",
-              "description": "This text is displayed only when more attempts remain. You can use the following variables: {{attemptsSpent}}, {{attempts}}, {{attemptsLeft}}, {{{score}}}, {{{maxScore}}}",
+              "description": "This text is displayed only when more attempts remain. You can use the following variables: {{attemptsSpent}}, {{attempts}}, {{attemptsLeft}}, {{{score}}}, {{scoreAsPercent}} and {{{maxScore}}}",
               "default": "",
               "_adapt": {
                 "translatable": true
@@ -98,7 +98,7 @@
         "_completionBody": {
           "type": "string",
           "title": "Default feedback",
-          "description": "This text overwrites the standard body attribute upon completion of the assessment. It may make use of the following variables: {{attemptsSpent}}, {{attempts}}, {{attemptsLeft}}, {{{score}}}, {{{maxScore}}}. {{{feedback}}}, representing the feedback assigned to the appropriate band, is also allowed",
+          "description": "This text overwrites the standard body attribute upon completion of the assessment. It may make use of the following variables: {{attemptsSpent}}, {{attempts}}, {{attemptsLeft}}, {{{score}}}, {{scoreAsPercent}} and {{{maxScore}}}. {{{feedback}}}, representing the feedback assigned to the appropriate band, is also allowed",
           "default": "This component you're reading is a results component.<br>You have finished the assessment.<br>You scored {{{score}}} out of {{{maxScore}}}. {{{feedback}}}",
           "_adapt": {
             "translatable": true

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -80,7 +80,7 @@
             "feedback": {
               "type": "string",
               "title": "Retry feedback",
-              "description": "This text is displayed only when more attempts remain. You can use the following variables: {{attemptsSpent}}, {{attempts}}, {{attemptsLeft}}, {{{score}}}, {{scoreAsPercent}} and {{{maxScore}}}",
+              "description": "This text is displayed only when more attempts remain. You can use the following variables: {{attemptsSpent}}, {{attempts}}, {{attemptsLeft}}, {{score}}, {{scoreAsPercent}} and {{maxScore}}",
               "default": "",
               "_adapt": {
                 "translatable": true
@@ -98,8 +98,8 @@
         "_completionBody": {
           "type": "string",
           "title": "Default feedback",
-          "description": "This text overwrites the standard body attribute upon completion of the assessment. It may make use of the following variables: {{attemptsSpent}}, {{attempts}}, {{attemptsLeft}}, {{{score}}}, {{scoreAsPercent}} and {{{maxScore}}}. {{{feedback}}}, representing the feedback assigned to the appropriate band, is also allowed",
-          "default": "This component you're reading is a results component.<br>You have finished the assessment.<br>You scored {{{score}}} out of {{{maxScore}}}. {{{feedback}}}",
+          "description": "This text overwrites the standard body attribute upon completion of the assessment. It may make use of the following variables: {{attemptsSpent}}, {{attempts}}, {{attemptsLeft}}, {{score}}, {{scoreAsPercent}} and {{maxScore}}. {{{feedback}}}, representing the feedback assigned to the appropriate band, is also allowed",
+          "default": "This component you're reading is a results component.<br>You have finished the assessment.<br>You scored {{score}} out of {{maxScore}}. {{{feedback}}}",
           "_adapt": {
             "translatable": true
           },


### PR DESCRIPTION
Fixes #82 

### Fix
* Adds `scoreAsPercent` to the help text in the schemas
* Removes triple squigglies from the schemas where it is unlikely to be used. For instance, there should generally not be a need to allow HTML tags in `maxScore`, so we can just recommend using double squigglies. This also aligns with the instructions in the readme.
