### PR TITLE
Fix: Clarify the behavior when _assessmentId is left blank (fixes #81)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The attributes listed below are used in *components.json* to configure **Assessm
 **instruction** (string): This optional text appears above the component. It is frequently used to
 guide the learner’s interaction with the component.
 
-**_assessmentId** (string): This value must match the [`_id` of the assessment](https://github.com/adaptlearning/adapt-contrib-assessment#attributes) for which results should be displayed.
+**_assessmentId** (string): This value must match the [`_id` of the assessment](https://github.com/adaptlearning/adapt-contrib-assessment#attributes) for which results should be displayed. If you only have *one* assessment, you can leave this blank (the article's `_assessment._id` must also be blank).
 
 **\_isVisibleBeforeCompletion** (boolean): Determines whether this component will be visible as the learner enters the assessment article or if it will be displayed only after the learner completes all question components. Acceptable values are `true` or `false`. The default is `false`.
 

--- a/properties.schema
+++ b/properties.schema
@@ -80,7 +80,7 @@
       "title": "Linked assessment ID",
       "inputType": "Text",
       "validators": [],
-      "help": "This is the unique name of the assessment for which results should be displayed. If you only have one assessment, you can leave this blank (the article's assessment ID must also be blank)"
+      "help": "This is the unique name of the assessment for which results should be displayed. If you only have one assessment, you can leave this blank (the article's assessment ID must also be blank)."
     },
     "_retry": {
       "type": "object",

--- a/properties.schema
+++ b/properties.schema
@@ -77,10 +77,10 @@
       "type": "string",
       "required": true,
       "default": "",
-      "title": "Assessment Name",
+      "title": "Linked assessment ID",
       "inputType": "Text",
       "validators": [],
-      "help": "This is the unique name of the assessment for which results should be displayed. If you only have one assessment you can leave this blank."
+      "help": "This is the unique name of the assessment for which results should be displayed. If you only have one assessment, you can leave this blank (the article's assessment ID must also be blank)"
     },
     "_retry": {
       "type": "object",

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -61,7 +61,7 @@
         "_assessmentId": {
           "type": "string",
           "title": "Linked assessment ID",
-          "description": "This is the unique name of the assessment for which results should be displayed. If you only have one assessment, you can leave this blank (the article's assessment ID must also be blank)",
+          "description": "This is the unique name of the assessment for which results should be displayed. If you only have one assessment, you can leave this blank (the article's assessment ID must also be blank).",
           "default": ""
         },
         "_retry": {

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -61,7 +61,7 @@
         "_assessmentId": {
           "type": "string",
           "title": "Linked assessment ID",
-          "description": "This is the unique name of the assessment for which results should be displayed. If you only have one assessment you can leave this blank",
+          "description": "This is the unique name of the assessment for which results should be displayed. If you only have one assessment, you can leave this blank (the article's assessment ID must also be blank)",
           "default": ""
         },
         "_retry": {


### PR DESCRIPTION
Fix #81 

### Fix
* Clarifies the behavior when `_assessmentId` is left blank. The article's assessment ID must _also_ be blank, and this was not made clear in the documentation or schemas.