### PR TITLE
Fix: Retry Assessment button does nothing when results are on a separate page (fixes #109)

### DIFF
--- a/js/assessmentResultsView.js
+++ b/js/assessmentResultsView.js
@@ -35,7 +35,10 @@ class AssessmentResultsView extends ComponentView {
    */
   onRetryClicked() {
     const state = this.model._state;
-    Adapt.assessment.get(state.id).reset(null, wasReset => {
+    // force the reset: an explicit retry click should always reset, even when
+    // the assessment is already complete and not configured to reset on revisit
+    // (e.g. _allowResetIfPassed). see #109
+    Adapt.assessment.get(state.id).reset(true, wasReset => {
       if (!wasReset) return;
 
       if (this.model.get('_retry')._routeToAssessment !== true) return;


### PR DESCRIPTION
Fixes #109

### Fix
The "Retry Assessment" button called the assessment reset without forcing it. When the results component sits on a different page from the assessment, the assessment's reset bails out (it is already complete in the session and not set to reset on revisit), so the click did nothing. This was most visible with "Allow retry once passed" (`_allowResetIfPassed`) enabled, since that is what makes the button appear after passing.

The retry click is an explicit, user-initiated reset and is already gated by the button's enabled state (retry allowed, attempts remaining), so it now forces the reset. Resetting on page revisit is unaffected, so `_allowResetIfPassed` on its own still resets only via the button, not automatically on revisit.

### Testing
1. Set up an assessment with "Allow retry once passed" (`_allowResetIfPassed`) enabled and infinite attempts.
2. Put the _assessmentResults_ component on a **separate page** from the assessment questions, with a feedback band that allows retry and `_routeToAssessment` enabled.
3. Answer all questions correctly to pass.
4. Go to the results page and click "Retry Assessment".
5. Before: nothing happens. After: the assessment resets and you are routed back to the questions.

Posted via collaboration with Claude Code